### PR TITLE
Remove local definition of mapIndexed and forEachIndexed in example

### DIFF
--- a/packages/dynamic_color/example/lib/core_palette_visualization.dart
+++ b/packages/dynamic_color/example/lib/core_palette_visualization.dart
@@ -158,9 +158,9 @@ class _RenderCorePalette extends StatelessWidget {
       corePalette.neutralVariant.asList,
     ];
     return Column(
-      children: colors.mapIndexed(
-        (List<int> tones, int i) {
-          return Row(
+      children: [
+        for (final (int i, List<int> tones) in colors.indexed)
+          Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               SizedBox(
@@ -172,9 +172,8 @@ class _RenderCorePalette extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 16),
-              ...tones.mapIndexed((int color, int i) {
-                final toneValue = TonalPalette.commonTones[i];
-                return Container(
+              for (final (int i, int color) in tones.indexed)
+                Container(
                   constraints: const BoxConstraints.tightFor(
                     height: 80,
                     width: 60,
@@ -182,32 +181,19 @@ class _RenderCorePalette extends StatelessWidget {
                   color: Color(color),
                   child: Center(
                     child: Text(
-                      toneValue.toString(),
+                      TonalPalette.commonTones[i].toString(),
                       style: captionStyle!.copyWith(
                         // For contrast
-                        color: toneValue > 50 ? Colors.black : Colors.white,
+                        color: TonalPalette.commonTones[i] > 50
+                            ? Colors.black
+                            : Colors.white,
                       ),
                     ),
                   ),
-                );
-              }),
+                ),
             ],
-          );
-        },
-      ).toList(),
+          ),
+      ],
     );
-  }
-}
-
-extension ExtendedIterable<E> on Iterable<E> {
-  /// Like Iterable<T>.map but the callback has index as second argument.
-  Iterable<T> mapIndexed<T>(T Function(E e, int i) f) {
-    var i = 0;
-    return map((e) => f(e, i++));
-  }
-
-  void forEachIndexed(void Function(E e, int i) f) {
-    var i = 0;
-    forEach((e) => f(e, i++));
   }
 }

--- a/packages/dynamic_color/example/pubspec.lock
+++ b/packages/dynamic_color/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.6.5"
+    version: "1.6.6"
   fake_async:
     dependency: transitive
     description:
@@ -82,14 +82,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -191,6 +183,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.4.0-17.0.pre"

--- a/packages/dynamic_color/example/pubspec.yaml
+++ b/packages/dynamic_color/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the dynamic_color package.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/packages/dynamic_color/pubspec.lock
+++ b/packages/dynamic_color/pubspec.lock
@@ -107,14 +107,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.18.1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -272,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   yaml:
     dependency: transitive
     description:
@@ -281,5 +281,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.4.0-17.0.pre"


### PR DESCRIPTION
The story about this change starts in https://github.com/dart-lang/collection/pull/305 that I wanted to add indexed variant of none/every/any but instead learnt about `.indexed` and the fact it's possibly (and maybe not) going to be deprecated `.thingsIndexed` in favor of `.indexed.` https://github.com/dart-lang/collection/pull/305#discussion_r1297484516 so I went ahead removing `.thingsIndexed` from my codebase and in the process even found a compiler bug! https://github.com/dart-lang/sdk/issues/53268

While searching for `.thingsIndexed` in my codebase and using `.indexed.` instead (which was a good thing as I could use list comprehension much better), I've learnt the only place IntelliJ's IDE's search engine is finding instances of `.mapIndexed` and `.forEachIndexed` is in examples of dynamic color library which my app uses, interestingly I had [two contributions](https://github.com/material-foundation/material-dynamic-color-flutter/pulls?q=is%3Apr+is%3Aclosed+author%3Aebraminio) to the library also when it wasn't merged to this package. Now I wonder while you aren't even using `collections`'s `mapIndexed` and `forEachIndexed`, is it possible to remove the uses in the dynamic color's example and just use the more recommended way so my IntelliJ's search result of my project can reach to zero.

Thanks!