### PR TITLE
[dynamic_color] Move flutter_test to dev_dependencies

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Move flutter_test to dev_dependencies
+
 ## 1.6.8 - 2023-10-17
 ### Changed
 - Broaden constraint for `material_color_utilities` to support it until its `1.0.0` release

--- a/packages/dynamic_color/pubspec.lock
+++ b/packages/dynamic_color/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     source: hosted
     version: "2.0.3"
   flutter_test:
-    dependency: "direct main"
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/dynamic_color/pubspec.yaml
+++ b/packages/dynamic_color/pubspec.yaml
@@ -18,14 +18,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_test:
-    sdk: flutter
   # Since this package is an SDK dependency, we need to support a range of versions.
   material_color_utilities: ">=0.2.0 < 1.0.0"
 
 dev_dependencies:
   cider: ">=0.1.3 <0.3.0"
   flutter_lints: ^2.0.0
+  flutter_test:
+    sdk: flutter
   meta: ^1.3.0
 
 flutter:


### PR DESCRIPTION
## Description

flutter_test has to be in dev_dependencies. In my package I face constraints problems due to it being in the normal dependencies.

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
