### PR TITLE
[google_fonts] Enhance font fallback

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0 - 2023-11-17
+### Added
+- Add font fallback mechanism. This update allows for more robust handling of unavailable fonts, ensuring graceful degradation to alternative fonts.
+
 ## 6.1.0 - 2023-09-20
 ### Added
 - Add an example where one can select any available font

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -116,9 +116,15 @@ TextStyle googleFontsTextStyle({
   pendingFontFutures.add(loadingFuture);
   loadingFuture.then((_) => pendingFontFutures.remove(loadingFuture));
 
+  final currentFontFamily = textStyle.fontFamily;
+
   return textStyle.copyWith(
     fontFamily: familyWithVariant.toString(),
-    fontFamilyFallback: [fontFamily],
+    fontFamilyFallback: [
+      fontFamily,
+      if (currentFontFamily != null) currentFontFamily,
+      ...?textStyle.fontFamilyFallback,
+    ],
   );
 }
 

--- a/packages/google_fonts/test/generated_font_methods_test.dart
+++ b/packages/google_fonts/test/generated_font_methods_test.dart
@@ -105,6 +105,22 @@ void main() {
     expect(outputTextStyle.fontFamily, equals('Lato_regular'));
   });
 
+  testWidgets('Combining text styles maintains fontFamily and fallback order',
+      (tester) async {
+    const textStyle = TextStyle();
+    final outputTextStyle = GoogleFonts.lato(
+      textStyle: GoogleFonts.notoColorEmoji(
+        textStyle: textStyle,
+      ),
+    );
+
+    expect(outputTextStyle.fontFamily, 'Lato_regular');
+    expect(
+      outputTextStyle.fontFamilyFallback,
+      ['Lato', 'NotoColorEmoji_regular', 'NotoColorEmoji'],
+    );
+  });
+
   ///////////////////////////
   // TextStyle param tests //
   ///////////////////////////


### PR DESCRIPTION
## Description

The main motivation behind this change is to improve the font fallback mechanism. This makes it possible to switch to another font if the current one does not support certain glyphs. 
  
For example, replace all emoticons with an emoji font:
```dart
/* ... */
theme: GoogleFonts.latoTextTheme(
  GoogleFonts.notoColorEmojiTextTheme(theme.textTheme),
);
/* ... */
```

With these changes, the app will still use the _lato_ font, but all emoji will be replaced by _notoColorEmoji_.

## Tests

Verifying that the text style correctly falls back to the next available font when the primary font is unavailable.

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
