### PR TITLE
[Enhancement] Use `InheritedModel` instead of `InheritedWidget` to avoid unnecessary rebuild

### DIFF
--- a/packages/adaptive_breakpoints/CHANGELOG.md
+++ b/packages/adaptive_breakpoints/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7 - 2023-12-06
+### Changed
+- Use `InheritedModel` instead of `InheritedWidget`
+
 ## 0.1.6 - 2023-02-03
 ### Added
 - Added screenshots

--- a/packages/adaptive_breakpoints/example/main.dart
+++ b/packages/adaptive_breakpoints/example/main.dart
@@ -191,7 +191,7 @@ class AdaptiveContainer extends StatelessWidget {
             color: color,
             decoration: decoration,
             foregroundDecoration: foregroundDecoration,
-            width: MediaQuery.of(context).size.width - (entry.margins * 2),
+            width: MediaQuery.sizeOf(context).width - (entry.margins * 2),
             height: height,
             margin: EdgeInsets.symmetric(horizontal: entry.margins),
             transform: transform,
@@ -520,7 +520,7 @@ AdaptiveWindowType getWindowType(BuildContext context) {
 /// function gives the developer access to the specific breakpoint entry and
 /// it's variables.
 BreakpointSystemEntry getBreakpointEntry(BuildContext context) {
-  double width = MediaQuery.of(context).size.width;
+  double width = MediaQuery.sizeOf(context).width;
   for (BreakpointSystemEntry entry in breakpointSystem) {
     if (entry.range.start <= width && width < entry.range.end + 1) {
       return entry;

--- a/packages/adaptive_breakpoints/lib/src/adaptive_breakpoints.dart
+++ b/packages/adaptive_breakpoints/lib/src/adaptive_breakpoints.dart
@@ -271,7 +271,7 @@ AdaptiveWindowType getWindowType(BuildContext context) {
 /// function gives the developer access to the specific breakpoint entry and
 /// it's variables.
 BreakpointSystemEntry getBreakpointEntry(BuildContext context) {
-  double width = MediaQuery.of(context).size.width;
+  double width = MediaQuery.sizeOf(context).width;
   for (BreakpointSystemEntry entry in breakpointSystem) {
     if (entry.range.start <= width && width < entry.range.end + 1) {
       return entry;

--- a/packages/adaptive_breakpoints/pubspec.yaml
+++ b/packages/adaptive_breakpoints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_breakpoints
 description: A Flutter package providing Material Design breakpoints for responsive layouts.
-version: 0.1.6
+version: 0.1.7
 repository: https://github.com/material-foundation/flutter-packages/tree/main/packages/adaptive_breakpoints
 issue_tracker: https://github.com/material-foundation/flutter-packages/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+adaptive_breakpoints%22
 screenshots:

--- a/packages/adaptive_components/CHANGELOG.md
+++ b/packages/adaptive_components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7 - 2023-12-06
+### Changed
+- Use `InheritedModel` instead of `InheritedWidget`
+
 ## 0.0.9 - 2023-02-03
 ### Added
 - Added screenshots

--- a/packages/adaptive_components/CHANGELOG.md
+++ b/packages/adaptive_components/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.7 - 2023-12-06
+## 0.0.10 - 2023-12-06
 ### Changed
 - Use `InheritedModel` instead of `InheritedWidget`
 

--- a/packages/adaptive_components/lib/src/adaptive_column.dart
+++ b/packages/adaptive_components/lib/src/adaptive_column.dart
@@ -106,11 +106,10 @@ class AdaptiveColumn extends StatelessWidget {
                     int rowGutters = 0;
                     for (AdaptiveContainer rowItem in row) {
                       // Periodic width is the width of 1 column + 1 gutter.
-                      double periodicWidth =
-                          (MediaQuery.sizeOf(context).width -
-                                  effectiveMargin * 2 +
-                                  effectiveGutter) /
-                              entry.columns;
+                      double periodicWidth = (MediaQuery.sizeOf(context).width -
+                              effectiveMargin * 2 +
+                              effectiveGutter) /
+                          entry.columns;
 
                       // For a row item with a column span of k, its width is
                       // k * column + (k - 1) * gutter, which equals

--- a/packages/adaptive_components/lib/src/adaptive_column.dart
+++ b/packages/adaptive_components/lib/src/adaptive_column.dart
@@ -107,7 +107,7 @@ class AdaptiveColumn extends StatelessWidget {
                     for (AdaptiveContainer rowItem in row) {
                       // Periodic width is the width of 1 column + 1 gutter.
                       double periodicWidth =
-                          (MediaQuery.of(context).size.width -
+                          (MediaQuery.sizeOf(context).width -
                                   effectiveMargin * 2 +
                                   effectiveGutter) /
                               entry.columns;

--- a/packages/adaptive_components/pubspec.yaml
+++ b/packages/adaptive_components/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_components
 description: A Flutter package to implement responsive layouts in Material Design.
-version: 0.0.9
+version: 0.0.10
 repository: https://github.com/material-foundation/flutter-packages/tree/main/packages/adaptive_components
 issue_tracker: https://github.com/material-foundation/flutter-packages/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+adaptive_components%22
 screenshots:

--- a/packages/adaptive_navigation/example/lib/custom_scaffold.dart
+++ b/packages/adaptive_navigation/example/lib/custom_scaffold.dart
@@ -25,7 +25,7 @@ class CustomScaffoldDemoState extends State<CustomScaffoldDemo> {
         onPressed: () {},
       ),
       navigationTypeResolver: (context) {
-        if (MediaQuery.of(context).size.width > 600) {
+        if (MediaQuery.sizeOf(context).width > 600) {
           return NavigationType.drawer;
         } else {
           return NavigationType.bottom;


### PR DESCRIPTION
## Description

The `MediaQuery.of(context)` API causes unnecessary rebuild when any property of MediaQuery changes. This PR solves that issue by making use `InheritedModel` instead of `InheritedWidget`.

## Tests

No changes required.

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`