### PR TITLE
[adaptive_navigation] use widget instead of icon

### DIFF
--- a/packages/adaptive_navigation/CHANGELOG.md
+++ b/packages/adaptive_navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Use Widget instead of Icon for navigation items
+
 ## 0.0.10 - 2023-12-06
 ### Changed
 - Use `InheritedModel` instead of `InheritedWidget` in example

--- a/packages/adaptive_navigation/CHANGELOG.md
+++ b/packages/adaptive_navigation/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.1.0 - 2024-01-10
 ### Changed
 -  **breaking** Use `Widget` instead of `Icon` for navigation items
 

--- a/packages/adaptive_navigation/CHANGELOG.md
+++ b/packages/adaptive_navigation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 ### Changed
-- Use Widget instead of Icon for navigation items
+-  **breaking** Use `Widget` instead of `Icon` for navigation items
 
 ## 0.0.10 - 2023-12-06
 ### Changed

--- a/packages/adaptive_navigation/example/lib/custom_scaffold.dart
+++ b/packages/adaptive_navigation/example/lib/custom_scaffold.dart
@@ -94,13 +94,13 @@ class CustomScaffoldDemoState extends State<CustomScaffoldDemo> {
 }
 
 const _allDestinations = [
-  AdaptiveScaffoldDestination(title: 'Alarm', icon: Icons.alarm),
-  AdaptiveScaffoldDestination(title: 'Book', icon: Icons.book),
-  AdaptiveScaffoldDestination(title: 'Cake', icon: Icons.cake),
-  AdaptiveScaffoldDestination(title: 'Directions', icon: Icons.directions),
-  AdaptiveScaffoldDestination(title: 'Email', icon: Icons.email),
-  AdaptiveScaffoldDestination(title: 'Favorite', icon: Icons.favorite),
-  AdaptiveScaffoldDestination(title: 'Group', icon: Icons.group),
-  AdaptiveScaffoldDestination(title: 'Headset', icon: Icons.headset),
-  AdaptiveScaffoldDestination(title: 'Info', icon: Icons.info),
+  AdaptiveScaffoldDestination(title: 'Alarm', icon: Icon(Icons.alarm)),
+  AdaptiveScaffoldDestination(title: 'Book', icon: Icon(Icons.book)),
+  AdaptiveScaffoldDestination(title: 'Cake', icon: Icon(Icons.cake)),
+  AdaptiveScaffoldDestination(title: 'Directions', icon: Icon(Icons.directions)),
+  AdaptiveScaffoldDestination(title: 'Email', icon: Icon(Icons.email)),
+  AdaptiveScaffoldDestination(title: 'Favorite', icon: Icon(Icons.favorite)),
+  AdaptiveScaffoldDestination(title: 'Group', icon: Icon(Icons.group)),
+  AdaptiveScaffoldDestination(title: 'Headset', icon: Icon(Icons.headset)),
+  AdaptiveScaffoldDestination(title: 'Info', icon: Icon(Icons.info)),
 ];

--- a/packages/adaptive_navigation/example/lib/default_scaffold.dart
+++ b/packages/adaptive_navigation/example/lib/default_scaffold.dart
@@ -91,13 +91,13 @@ class DefaultScaffoldDemoState extends State<DefaultScaffoldDemo> {
 }
 
 const _allDestinations = [
-  AdaptiveScaffoldDestination(title: 'Alarm', icon: Icons.alarm),
-  AdaptiveScaffoldDestination(title: 'Book', icon: Icons.book),
-  AdaptiveScaffoldDestination(title: 'Cake', icon: Icons.cake),
-  AdaptiveScaffoldDestination(title: 'Directions', icon: Icons.directions),
-  AdaptiveScaffoldDestination(title: 'Email', icon: Icons.email),
-  AdaptiveScaffoldDestination(title: 'Favorite', icon: Icons.favorite),
-  AdaptiveScaffoldDestination(title: 'Group', icon: Icons.group),
-  AdaptiveScaffoldDestination(title: 'Headset', icon: Icons.headset),
-  AdaptiveScaffoldDestination(title: 'Info', icon: Icons.info),
+  AdaptiveScaffoldDestination(title: 'Alarm', icon: Icon(Icons.alarm)),
+  AdaptiveScaffoldDestination(title: 'Book', icon: Icon(Icons.book)),
+  AdaptiveScaffoldDestination(title: 'Cake', icon: Icon(Icons.cake)),
+  AdaptiveScaffoldDestination(title: 'Directions', icon: Icon(Icons.directions)),
+  AdaptiveScaffoldDestination(title: 'Email', icon: Icon(Icons.email)),
+  AdaptiveScaffoldDestination(title: 'Favorite', icon: Icon(Icons.favorite)),
+  AdaptiveScaffoldDestination(title: 'Group', icon: Icon(Icons.group)),
+  AdaptiveScaffoldDestination(title: 'Headset', icon: Icon(Icons.headset)),
+  AdaptiveScaffoldDestination(title: 'Info', icon: Icon(Icons.info)),
 ];

--- a/packages/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
+++ b/packages/adaptive_navigation/lib/src/adaptive_navigation_scaffold.dart
@@ -31,7 +31,7 @@ enum NavigationType {
 /// [ListTile].
 class AdaptiveScaffoldDestination {
   final String title;
-  final IconData icon;
+  final Widget icon;
 
   const AdaptiveScaffoldDestination({
     required this.title,
@@ -194,7 +194,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
           if (drawerHeader != null) drawerHeader!,
           for (int i = 0; i < destinations.length; i++)
             ListTile(
-              leading: Icon(destinations[i].icon),
+              leading: destinations[i].icon,
               title: Text(destinations[i].title),
               onTap: () {
                 onDestinationSelected?.call(i);
@@ -227,7 +227,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
         items: [
           for (final destination in bottomDestinations)
             BottomNavigationBarItem(
-              icon: Icon(destination.icon),
+              icon: destination.icon,
               label: destination.title,
             ),
         ],
@@ -262,7 +262,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
             destinations: [
               for (final destination in railDestinations)
                 NavigationRailDestination(
-                  icon: Icon(destination.icon),
+                  icon: destination.icon,
                   label: Text(destination.title),
                 ),
             ],
@@ -308,7 +308,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
             if (drawerHeader != null) drawerHeader!,
             for (final destination in destinations)
               ListTile(
-                leading: Icon(destination.icon),
+                leading: destination.icon,
                 title: Text(destination.title),
                 selected: destinations.indexOf(destination) == selectedIndex,
                 onTap: () => _destinationTapped(destination),
@@ -346,7 +346,7 @@ class AdaptiveNavigationScaffold extends StatelessWidget {
               if (drawerHeader != null) drawerHeader!,
               for (final destination in destinations)
                 ListTile(
-                  leading: Icon(destination.icon),
+                  leading: destination.icon,
                   title: Text(destination.title),
                   selected: destinations.indexOf(destination) == selectedIndex,
                   onTap: () => _destinationTapped(destination),

--- a/packages/adaptive_navigation/pubspec.yaml
+++ b/packages/adaptive_navigation/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_navigation
 description: A Flutter package providing adaptive switching between various navigation components.
-version: 0.0.10
+version: 0.1.0
 repository: https://github.com/material-foundation/flutter-packages/tree/main/packages/adaptive_navigation
 issue_tracker: https://github.com/material-foundation/flutter-packages/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+adaptive_navigation%22
 screenshots:

--- a/packages/adaptive_navigation/test/adaptive_navigation_test.dart
+++ b/packages/adaptive_navigation/test/adaptive_navigation_test.dart
@@ -9,15 +9,15 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
 
     const allDestinations = [
-      AdaptiveScaffoldDestination(title: 'Alarm', icon: Icons.alarm),
-      AdaptiveScaffoldDestination(title: 'Book', icon: Icons.book),
-      AdaptiveScaffoldDestination(title: 'Cake', icon: Icons.cake),
-      AdaptiveScaffoldDestination(title: 'Directions', icon: Icons.directions),
-      AdaptiveScaffoldDestination(title: 'Email', icon: Icons.email),
-      AdaptiveScaffoldDestination(title: 'Favorite', icon: Icons.favorite),
-      AdaptiveScaffoldDestination(title: 'Group', icon: Icons.group),
-      AdaptiveScaffoldDestination(title: 'Headset', icon: Icons.headset),
-      AdaptiveScaffoldDestination(title: 'Info', icon: Icons.info),
+      AdaptiveScaffoldDestination(title: 'Alarm', icon: Icon(Icons.alarm)),
+      AdaptiveScaffoldDestination(title: 'Book', icon: Icon(Icons.book)),
+      AdaptiveScaffoldDestination(title: 'Cake', icon: Icon(Icons.cake)),
+      AdaptiveScaffoldDestination(title: 'Directions', icon: Icon(Icons.directions)),
+      AdaptiveScaffoldDestination(title: 'Email', icon: Icon(Icons.email)),
+      AdaptiveScaffoldDestination(title: 'Favorite', icon: Icon(Icons.favorite)),
+      AdaptiveScaffoldDestination(title: 'Group', icon: Icon(Icons.group)),
+      AdaptiveScaffoldDestination(title: 'Headset', icon: Icon(Icons.headset)),
+      AdaptiveScaffoldDestination(title: 'Info', icon: Icon(Icons.info)),
     ];
 
     await tester.pumpWidget(


### PR DESCRIPTION
## Description

Until now, it has not been possible to add a badge to a navigation element because the icon type is fixed. 
This is a breaking change! 

## Tests

Updated the existing tests

## Issues
Fixes #

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
