### PR TITLE
Revert "remove unused import"

### DIFF
--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 // TODO(andrewkolos): The flutter framework wishes to add a new class named

--- a/packages/google_fonts/test/generated_font_methods_test.dart
+++ b/packages/google_fonts/test/generated_font_methods_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_fonts/google_fonts.dart';


### PR DESCRIPTION
This reverts commit e32cc8e6546b5cf12cc2e6a456f0428f68f59d8a.

## Description

It seems the dart:ui improt was not unused. See: https://stackoverflow.com/questions/78090711/error-type-fontfeature-not-found-flutter-google-fonts-package-error

## Tests

*Please describe the tests that you added or updated to verify your changes.*

## Issues
Fixes #567 #568 

## Checklist

- [ ] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [ ] I've updated the package `CHANGELOG.md`
