### PR TITLE
Update `compileSdkVersion` from `31` to `34`

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Update `compileSdkVersion` to `34`
+
 ## 1.7.0 - 2024-03-01
 ### Changed
 - Update `material_color_utilities` to `0.8.0`

--- a/packages/dynamic_color/android/build.gradle
+++ b/packages/dynamic_color/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'io.material.plugins.dynamic_color'
 
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Description

I updated the `compileSdkVersion` from `31` to `34`

## Issues
Fixes the need for an old SDK version

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
