### PR TITLE
Fix missing import for dart:ui in google_fonts_base.dart

### DIFF
--- a/packages/google_fonts/CHANGELOG.md
+++ b/packages/google_fonts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.1 - 2024-07-17
+### Fixed
+- Added missing import for `dart:ui` in `google_fonts_base.dart` to fix the `FontFeature` not found error.
+
 ## 6.2.1 - 2024-03-04
 ### Changed
 - Update lowest supported Flutter version to current stable (`3.19.2`)

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -1,7 +1,7 @@
 // Copyright 2019 The Flutter team. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import 'dart:ui';
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 // TODO(andrewkolos): The flutter framework wishes to add a new class named


### PR DESCRIPTION
## Description

I encountered an error when using the google_fonts package, specifically version 6.2.0. The error is related to the missing FontFeature type. It appears that the import for dart:ui is missing in the google_fonts_base.dart file. Adding the missing import resolves the issue and ensures that the FontFeature type is recognized.

## Tests

The change is a simple import addition, which doesn't affect the logic of the package but fixes the compilation error. Manual testing was performed to ensure the package compiles and works correctly after the import addition.

## Issues
Fixes #

I did not create an issue for this fix. This pull request addresses the following error directly:

AppData/Local/Pub/Cache/hosted/pub.dev/google_fonts-6.2.0/lib/src/google_fonts_base.dart:69:8: Error: Type 'FontFeature' not found.
  List<FontFeature>? fontFeatures,
       ^^^^^^^^^^^
AppData/Local/Pub/Cache/hosted/pub.dev/google_fonts-6.2.0/lib/src/google_fonts_base.dart:69:8: Error: 'FontFeature' isn't a type.
  List<FontFeature>? fontFeatures,
       ^^^^^^^^^^^


## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
