### PR TITLE
Allow custom implementations for font data loading.

### DIFF
--- a/packages/google_fonts/README.md
+++ b/packages/google_fonts/README.md
@@ -128,6 +128,27 @@ For HTTP fetching to work, certain platforms require additional steps when runni
 
 Learn more at https://docs.flutter.dev/development/data-and-backend/networking#platform-notes.
 
+### Custom font loaders
+
+Once the data for a font is successfully retrieved, it must be loaded into the Flutter engine for use. The default font loader, `DefaultGoogleFontsLoader`, uses the flutter `FontLoader`. You may also provide a custom font loader by implementing the `GoogleFontsLoader` interface and passing it in the global config object. For example:
+
+```dart
+// Custom font loader that performs some logging and then defers to the default implementation.
+class MyFontLoader implements GoogleFontsLoader {
+  final _impl = DefaultGoogleFontsLoader();
+
+  @override
+  Future<void> loadFont(String familyName, Future<ByteData> bytes) async {
+    final data = await bytes;
+    log('Loaded font $familyName; size ${data.lengthInBytes}');
+    return _impl.loadFont(familyName, Future.value(data));
+  }
+}
+
+// Elsewhere:
+GoogleFonts.config.fontLoader = MyFontLoader();
+```
+
 ## Bundling fonts when releasing
 
 The `google_fonts` package will automatically use matching font files in your `pubspec.yaml`'s

--- a/packages/google_fonts/lib/google_fonts.dart
+++ b/packages/google_fonts/lib/google_fonts.dart
@@ -9,6 +9,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 
 import 'src/google_fonts_base.dart';
+import 'src/google_fonts_loader.dart';
 import 'src/google_fonts_parts/part_a.dart';
 import 'src/google_fonts_parts/part_b.dart';
 import 'src/google_fonts_parts/part_c.dart';
@@ -36,12 +37,17 @@ import 'src/google_fonts_parts/part_x.dart';
 import 'src/google_fonts_parts/part_y.dart';
 import 'src/google_fonts_parts/part_z.dart';
 
+export 'src/google_fonts_loader.dart';
+
 /// A collection of properties used to specify custom behavior of the
 /// GoogleFonts library.
 class _Config {
   /// Whether or not the GoogleFonts library can make requests to
   /// [fonts.google.com](https://fonts.google.com/) to retrieve font files.
   var allowRuntimeFetching = true;
+
+  /// The instance used to load font data into the Flutter engine.
+  GoogleFontsLoader fontLoader = DefaultGoogleFontsLoader();
 }
 
 /// Provides configuration, and static methods to obtain [TextStyle]s and [TextTheme]s.

--- a/packages/google_fonts/lib/src/google_fonts_base.dart
+++ b/packages/google_fonts/lib/src/google_fonts_base.dart
@@ -214,9 +214,8 @@ Future<void> loadFontByteData(
   final fontData = await byteData;
   if (fontData == null) return;
 
-  final fontLoader = FontLoader(familyWithVariantString);
-  fontLoader.addFont(Future.value(fontData));
-  await fontLoader.load();
+  final fontLoader = GoogleFonts.config.fontLoader;
+  await fontLoader.loadFont(familyWithVariantString, Future.value(fontData));
 }
 
 /// Returns [GoogleFontsVariant] from [variantsToCompare] that most closely

--- a/packages/google_fonts/lib/src/google_fonts_loader.dart
+++ b/packages/google_fonts/lib/src/google_fonts_loader.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart' show FontLoader;
+
+/// Abstract base class for implementations that load font data into the Flutter
+/// engine.
+abstract class GoogleFontsLoader {
+  /// Loads the given font family and its font data into the Flutter engine,
+  /// making the font available for use.
+  Future<void> loadFont(String familyName, Future<ByteData> bytes);
+}
+
+/// The default font loader, using the Flutter default [FontLoader].
+class DefaultGoogleFontsLoader implements GoogleFontsLoader {
+  @override
+  Future<void> loadFont(String familyName, Future<ByteData> bytes) async {
+    final loader = FontLoader(familyName);
+    loader.addFont(bytes);
+    await loader.load();
+  }
+}


### PR DESCRIPTION
This adds a new public API, `GoogleFontsLoader`, and a corresponding new instance field `fontLoader` in the global `GoogleFonts.config` class.

The new API allows users to hook the loading of fonts into the Flutter engine, which is useful in scenarios where the actual font data is needed for other purposes. The newly added default font loader simply uses Flutter's `FontLoader` as before.

Happy to make any changes!

## Description

Any application that wishes to interact with the TTF data for a font retrieved via Google Fonts can use this API to access it. Issue #102 states one such example, using the popular Flutter pdf package to embed text using a font retrieved with this package.

## Tests

Added test `loadFontIfNecessary uses specified font loader` and tested API use locally.

## Issues
Fixes #102

## Checklist

- [X] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [ ] I've updated the package `CHANGELOG.md`

I did not update `CHANGELOG.md` because I am not aware of how the maintainers of this package would intend to release this change.