### PR TITLE
[dynamic_color] Move flutter_test to dev_dependencies

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Update `compileSdkVersion` to `34`
 - Fix lints
 
+### Fixed
+- Move flutter_test to dev_dependencies
+
 ## 1.7.0 - 2024-03-01
 ### Changed
 - Update `material_color_utilities` to `0.8.0`

--- a/packages/dynamic_color/lib/test_utils.dart
+++ b/packages/dynamic_color/lib/test_utils.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+// ignore: depend_on_referenced_packages
 import 'package:flutter_test/flutter_test.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
 

--- a/packages/dynamic_color/pubspec.lock
+++ b/packages/dynamic_color/pubspec.lock
@@ -95,7 +95,7 @@ packages:
     source: hosted
     version: "4.0.0"
   flutter_test:
-    dependency: "direct main"
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/dynamic_color/pubspec.yaml
+++ b/packages/dynamic_color/pubspec.yaml
@@ -18,8 +18,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_test:
-    sdk: flutter
   # Since this package is an SDK dependency, we need to support a range of versions.
   # See https://github.com/flutter/flutter/blob/main/packages/flutter/pubspec.yaml for current version used by the SDK.
   material_color_utilities: ">=0.2.0 <= 0.11.1"
@@ -27,6 +25,8 @@ dependencies:
 dev_dependencies:
   cider: ">=0.1.3 <0.3.0"
   flutter_lints: ^4.0.0
+  flutter_test:
+    sdk: flutter
   meta: ^1.3.0
 
 flutter:


### PR DESCRIPTION
## Description

I'm running into the problem again that your direct dependency on `flutter_test` doesn't allow me to update `test` in my packages which I urgently need to fix a bug.
Since the code is only used for testing it is fine to import a dependency from dev_dependencies in lib/.

Same as https://github.com/material-foundation/flutter-packages/pull/499, but with an added ignore.
I know it's annoying that I come back with it again, but I really need it.

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
