### PR TITLE
[dynamic_color] Use Flutter's preferred Android compileSdkVersion

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Changed
+- Update `compileSdkVersion` to `flutter.compileSdkVersion`
+
 ## 1.8.1 - 2025-08-01
 ### Fixed
 - Revert moving flutter_test to dev_dependencies

--- a/packages/dynamic_color/android/build.gradle
+++ b/packages/dynamic_color/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'io.material.plugins.dynamic_color'
 
-    compileSdkVersion 34
+    compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
## Description

Avoid relying on an old Android SDK for compiling the package.

Flutter's preferred compileSdkVersion is higher than 34: https://github.com/flutter/flutter/blob/d93e2d4b82ba2cc1b730948a81f823d52374d5dc/packages/flutter_tools/lib/src/android/gradle_utils.dart#L52

## Tests

N/A

## Issues

N/A

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
