### PR TITLE
Fix missing dynamic ColorScheme surface roles

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 1.9.0 - 2025-08-04
+### Fixed
+- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649)
+
 ### Added
 - Add support for AGP 9
 

--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.9.0 - 2025-08-04
+## 1.9.0 - 2025-08-06
 ### Fixed
 - Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649)
 

--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,11 +1,22 @@
-## 1.9.0 - 2025-08-06
+# Changelog
+
+- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649))
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.9.0 - 2025-08-07
+
 ### Fixed
-- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649)
+
+- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649))
 
 ### Added
+
 - Add support for AGP 9
 
 ### Changed
+
 - Migrate to Kotlin DSL in Android
 - Update `compileSdk` to `flutter.compileSdkVersion`
 - Update `minSdk` to `24`
@@ -14,11 +25,15 @@
 - Update testing docs and examples to use `package:dynamic_color_testing/dynamic_color_testing.dart`
 
 ## 1.8.1 - 2025-08-01
+
 ### Fixed
+
 - Revert moving flutter_test to dev_dependencies
 
 ## 1.8.0 - 2025-08-01
+
 ### Changed
+
 - Update `material_color_utilities` upper constraint to `0.13.0`
 - Update other dependencies
 - Update `compileSdkVersion` to `34`
@@ -26,129 +41,184 @@
 - Add Swift Package Manager compatibility [\#633](https://github.com/material-foundation/flutter-packages/issues/633).
 
 ### Fixed
+
 - Move flutter_test to dev_dependencies
 
 ## 1.7.0 - 2024-03-01
+
 ### Changed
+
 - Update `material_color_utilities` to `0.8.0`
 
 ## 1.6.9 - 2023-12-16
+
 ### Changed
+
 - Use `DynamicColors.isDynamicColorAvailable` from `com.google.android.material:material` to verify if dynamic colors are available on Android
 
 ## 1.6.8 - 2023-10-17
+
 ### Changed
+
 - Broaden constraint for `material_color_utilities` to support it until its `1.0.0` release
 
 ## 1.6.7 - 2023-09-15
+
 ### Fixed
+
 - Upgraded dependencies
 
 ## 1.6.6 - 2023-07-04
+
 ### Changed
+
 - Improved documentation for content-based color schemes
 
 ## 1.6.5 - 2023-05-15
+
 ### Changed
+
 - Broaden constraint for `material_color_utilities` to support multiple Flutter SDK versions
 
 ## 1.6.4 - 2023-05-05
+
 ### Changed
+
 - Update constraint for `material_color_utilities` to `0.5.0`
 
 ## 1.6.3 - 2023-04-04
+
 ### Changed
+
 - Update constraint for `material_color_utilities` to `0.3.0`
 
 ## 1.6.2 - 2023-02-03
+
 ### Added
+
 - Added screenshots
 
 ## 1.6.1 - 2023-02-03
+
 ### Changed
+
 - Update pubspec `repository`
 
 ## 1.6.0 - 2023-01-31
+
 ### Added
+
 - Add support for `outlineVariant` and `scrim` colors
 
 ### Changed
+
 - Update constraint for `material_color_utilities` to `0.2.0`
 - Update Flutter constraint
 - Make return value of toColorScheme extension method non-nullable ([\#55](https://github.com/material-foundation/material-dynamic-color-flutter/pull/55))
 
 ## 1.5.4 - 2022-09-02
+
 ### Changed
+
 - Update constraint for Flutter SDK
 
 ## 1.5.3 - 2022-08-09
+
 ### Changed
+
 - Update constraint for `material_color_utilities`
 
 ## 1.5.2 - 2022-08-02
+
 ### Added
+
 - Add support for DWM/Windows Aero's color ([\#50](https://github.com/material-foundation/material-dynamic-color-flutter/pull/50))
 - Add support for GTK's accent color on Linux ([\#47](https://github.com/material-foundation/material-dynamic-color-flutter/pull/47))
 - Add example tests
 
 ### Changed
+
 - Expand and improve README
 - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `colorPalette` to `corePalette`
 - Improve `DynamicColorBuilder` short-circuiting logic if dynamic color is detected
 - Tweak debugging messages
 
 ## 1.4.0 - 2022-05-31
+
 ### Added
+
 - Add support for Windows' accent color ([\#43](https://github.com/material-foundation/material-dynamic-color-flutter/pull/43))
 
 ### Changed
+
 - Rename `DynamicColorPlugin.getControlAccentColor` to `DynamicColorPlugin.getAccentColor`
 - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `controlAccentColor` to `accentColor`
 
 ## 1.3.0 - 2022-05-25
+
 ### Added
+
 - Add support for macOS' control accent color ([\#42](https://github.com/material-foundation/material-dynamic-color-flutter/pull/42))
   - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `colors` to `colorPalette`
 
 ## 1.2.3 - 2022-05-23
+
 ### Changed
+
 - Tweak pubspec description
 
 ## 1.2.2 - 2022-04-25
+
 ### Changed
+
 - Update lower Flutter SDK bound
 
 ## 1.2.0 - 2022-03-24
+
 ### Changed
+
 - Improve examples: show how to create dynamic and fallback color schemes, and use harmonization for color schemes and custom colors
 
 ## 1.1.2 - 2022-02-15
+
 ### Changed
+
 - Move samples to their own library
 
 ## 1.1.1 - 2022-02-14
+
 ### Changed
+
 - Provide sample `CorePalette`s and corresponding `ColorScheme`s to test utils
 - Make the extension method which converts a `CorePalette` to a `ColorScheme` public
 
 ## 1.1.0 - 2022-02-08
+
 ### Changed
+
 - Qualify builder parameters (`light` => `lightDynamic`, `dark` => `darkDynamic`) for clarity
 
 ## 1.0.1 - 2022-02-02
+
 ### Changed
+
 - Polish README and examples
 
 ## 1.0.0 - 2022-02-02
+
 ### Added
+
 - Add missing semantic colors to harmonization from updated m3 color scheme
 
 ### Changed
+
 - `DynamicColorBuilder`'s `builder` now provides a light and dark `ColorScheme` rather than a `CorePalette`
   - Advanced users can still obtain the palette with `DynamicColorPlugin.getCorePalette()`
 
 ## 0.1.0 - 2021-10-29
+
 ### Added
+
 - Create `CorePalette` and `TonalPalette` classes
 - Create `DynamicColorPlugin` plugin
 - Create convenience `DynamicColorBuilder` widget

--- a/packages/dynamic_color/example/test/widget_test.dart
+++ b/packages/dynamic_color/example/test/widget_test.dart
@@ -40,6 +40,9 @@ void main() {
     DynamicColorTestingUtils.setMockDynamicColors(
       accentColor: Colors.green,
     );
+    final expectedColor = ColorScheme.fromSeed(
+      seedColor: Colors.green,
+    ).primary;
 
     await tester.pumpWidget(
       DynamicColorBuilder(
@@ -52,7 +55,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final container = tester.widget<Container>(find.byKey(key));
-    expect(container.color, const Color(0xff006e1c));
+    expect(container.color, expectedColor);
   });
 
   testWidgets('Verify fallback color is used', (WidgetTester tester) async {

--- a/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
+++ b/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
@@ -16,6 +16,14 @@ extension CorePaletteToColorScheme on CorePalette {
         scheme = Scheme.darkFromCorePalette(this);
         break;
     }
+
+    // Start from seeded values to populate newer ColorScheme roles introduced
+    // after the legacy Scheme API was defined (for example, surfaceContainer*).
+    // We then override roles that must stay aligned with the OS-provided dynamic
+    // palette values from [scheme]. Returning fromSeed directly would drift these
+    // roles away from Android's dynamic color output.
+    // TODO(#680): Migrate this conversion to MCU DynamicScheme/CorePalettes so
+    // all roles can be resolved from one canonical dynamic-color path.
     final colorScheme = ColorScheme.fromSeed(
       seedColor: Color(scheme.primary),
       brightness: brightness,

--- a/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
+++ b/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
@@ -22,7 +22,7 @@ extension CorePaletteToColorScheme on CorePalette {
     // We then override roles that must stay aligned with the OS-provided dynamic
     // palette values from [scheme]. Returning fromSeed directly would drift these
     // roles away from Android's dynamic color output.
-    // TODO(#680): Migrate this conversion to MCU DynamicScheme/CorePalettes so
+    // TODO(#363): Migrate this conversion to MCU DynamicScheme/CorePalettes so
     // all roles can be resolved from one canonical dynamic-color path.
     final colorScheme = ColorScheme.fromSeed(
       seedColor: Color(scheme.primary),

--- a/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
+++ b/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
@@ -16,7 +16,12 @@ extension CorePaletteToColorScheme on CorePalette {
         scheme = Scheme.darkFromCorePalette(this);
         break;
     }
-    return ColorScheme(
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: Color(scheme.primary),
+      brightness: brightness,
+    );
+
+    return colorScheme.copyWith(
       primary: Color(scheme.primary),
       onPrimary: Color(scheme.onPrimary),
       primaryContainer: Color(scheme.primaryContainer),
@@ -37,14 +42,14 @@ extension CorePaletteToColorScheme on CorePalette {
       outlineVariant: Color(scheme.outlineVariant),
       surface: Color(scheme.surface),
       onSurface: Color(scheme.onSurface),
-      surfaceContainerHighest: Color(scheme.surfaceVariant),
+      surfaceVariant: Color(scheme.surfaceVariant),
       onSurfaceVariant: Color(scheme.onSurfaceVariant),
       inverseSurface: Color(scheme.inverseSurface),
       onInverseSurface: Color(scheme.inverseOnSurface),
       inversePrimary: Color(scheme.inversePrimary),
       shadow: Color(scheme.shadow),
+      surfaceTint: Color(scheme.primary),
       scrim: Color(scheme.scrim),
-      brightness: brightness,
     );
   }
 }

--- a/packages/dynamic_color/pubspec.lock
+++ b/packages/dynamic_color/pubspec.lock
@@ -175,10 +175,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: "direct main"
     description:
@@ -191,10 +191,10 @@ packages:
     dependency: "direct dev"
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -276,18 +276,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   version_manipulation:
     dependency: transitive
     description:
@@ -313,5 +313,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
+++ b/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
@@ -1,0 +1,61 @@
+import 'package:dynamic_color/src/corepalette_to_colorscheme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
+
+void main() {
+  group('CorePalette.toColorScheme', () {
+    const sourceColor = Color(0xff00bfa5);
+
+    test('fills the new surface roles for light schemes', () {
+      final corePalette = CorePalette.of(sourceColor.value);
+      final colorScheme = corePalette.toColorScheme();
+      final seedScheme = ColorScheme.fromSeed(
+        seedColor: Color(Scheme.lightFromCorePalette(corePalette).primary),
+      );
+
+      expect(colorScheme.surface, seedScheme.surface);
+      expect(colorScheme.surfaceDim, seedScheme.surfaceDim);
+      expect(colorScheme.surfaceBright, seedScheme.surfaceBright);
+      expect(
+        colorScheme.surfaceContainerLowest,
+        seedScheme.surfaceContainerLowest,
+      );
+      expect(colorScheme.surfaceContainerLow, seedScheme.surfaceContainerLow);
+      expect(colorScheme.surfaceContainer, seedScheme.surfaceContainer);
+      expect(colorScheme.surfaceContainerHigh, seedScheme.surfaceContainerHigh);
+      expect(
+        colorScheme.surfaceContainerHighest,
+        seedScheme.surfaceContainerHighest,
+      );
+      expect(colorScheme.surfaceTint, seedScheme.surfaceTint);
+    });
+
+    test('fills the new surface roles for dark schemes', () {
+      final corePalette = CorePalette.of(sourceColor.value);
+      final colorScheme = corePalette.toColorScheme(
+        brightness: Brightness.dark,
+      );
+      final seedScheme = ColorScheme.fromSeed(
+        seedColor: Color(Scheme.darkFromCorePalette(corePalette).primary),
+        brightness: Brightness.dark,
+      );
+
+      expect(colorScheme.surface, seedScheme.surface);
+      expect(colorScheme.surfaceDim, seedScheme.surfaceDim);
+      expect(colorScheme.surfaceBright, seedScheme.surfaceBright);
+      expect(
+        colorScheme.surfaceContainerLowest,
+        seedScheme.surfaceContainerLowest,
+      );
+      expect(colorScheme.surfaceContainerLow, seedScheme.surfaceContainerLow);
+      expect(colorScheme.surfaceContainer, seedScheme.surfaceContainer);
+      expect(colorScheme.surfaceContainerHigh, seedScheme.surfaceContainerHigh);
+      expect(
+        colorScheme.surfaceContainerHighest,
+        seedScheme.surfaceContainerHighest,
+      );
+      expect(colorScheme.surfaceTint, seedScheme.surfaceTint);
+    });
+  });
+}

--- a/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
+++ b/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
@@ -7,6 +7,32 @@ void main() {
   group('CorePalette.toColorScheme', () {
     const sourceColor = Color(0xff00bfa5);
 
+    test('preserves legacy dynamic roles from Scheme for light and dark', () {
+      final corePalette = CorePalette.of(sourceColor.value);
+
+      final lightColorScheme = corePalette.toColorScheme();
+      final lightScheme = Scheme.lightFromCorePalette(corePalette);
+      expect(lightColorScheme.primary, Color(lightScheme.primary));
+      expect(lightColorScheme.onPrimary, Color(lightScheme.onPrimary));
+      expect(lightColorScheme.primaryContainer, Color(lightScheme.primaryContainer));
+      expect(lightColorScheme.onPrimaryContainer, Color(lightScheme.onPrimaryContainer));
+      expect(lightColorScheme.surface, Color(lightScheme.surface));
+      expect(lightColorScheme.surfaceVariant, Color(lightScheme.surfaceVariant));
+      expect(lightColorScheme.surfaceTint, Color(lightScheme.primary));
+
+      final darkColorScheme = corePalette.toColorScheme(
+        brightness: Brightness.dark,
+      );
+      final darkScheme = Scheme.darkFromCorePalette(corePalette);
+      expect(darkColorScheme.primary, Color(darkScheme.primary));
+      expect(darkColorScheme.onPrimary, Color(darkScheme.onPrimary));
+      expect(darkColorScheme.primaryContainer, Color(darkScheme.primaryContainer));
+      expect(darkColorScheme.onPrimaryContainer, Color(darkScheme.onPrimaryContainer));
+      expect(darkColorScheme.surface, Color(darkScheme.surface));
+      expect(darkColorScheme.surfaceVariant, Color(darkScheme.surfaceVariant));
+      expect(darkColorScheme.surfaceTint, Color(darkScheme.primary));
+    });
+
     test('fills the new surface roles for light schemes', () {
       final corePalette = CorePalette.of(sourceColor.value);
       final colorScheme = corePalette.toColorScheme();

--- a/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
+++ b/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
@@ -10,11 +10,16 @@ void main() {
     test('fills the new surface roles for light schemes', () {
       final corePalette = CorePalette.of(sourceColor.value);
       final colorScheme = corePalette.toColorScheme();
+      final scheme = Scheme.lightFromCorePalette(corePalette);
       final seedScheme = ColorScheme.fromSeed(
-        seedColor: Color(Scheme.lightFromCorePalette(corePalette).primary),
+        seedColor: Color(scheme.primary),
       );
 
-      expect(colorScheme.surface, seedScheme.surface);
+      // Keep legacy dynamic-color roles sourced from MCU's Scheme.
+      expect(colorScheme.surface, Color(scheme.surface));
+      expect(colorScheme.surfaceTint, Color(scheme.primary));
+
+      // New Material surface roles should be populated from seeded values.
       expect(colorScheme.surfaceDim, seedScheme.surfaceDim);
       expect(colorScheme.surfaceBright, seedScheme.surfaceBright);
       expect(
@@ -28,7 +33,6 @@ void main() {
         colorScheme.surfaceContainerHighest,
         seedScheme.surfaceContainerHighest,
       );
-      expect(colorScheme.surfaceTint, seedScheme.surfaceTint);
     });
 
     test('fills the new surface roles for dark schemes', () {
@@ -36,12 +40,17 @@ void main() {
       final colorScheme = corePalette.toColorScheme(
         brightness: Brightness.dark,
       );
+      final scheme = Scheme.darkFromCorePalette(corePalette);
       final seedScheme = ColorScheme.fromSeed(
-        seedColor: Color(Scheme.darkFromCorePalette(corePalette).primary),
+        seedColor: Color(scheme.primary),
         brightness: Brightness.dark,
       );
 
-      expect(colorScheme.surface, seedScheme.surface);
+      // Keep legacy dynamic-color roles sourced from MCU's Scheme.
+      expect(colorScheme.surface, Color(scheme.surface));
+      expect(colorScheme.surfaceTint, Color(scheme.primary));
+
+      // New Material surface roles should be populated from seeded values.
       expect(colorScheme.surfaceDim, seedScheme.surfaceDim);
       expect(colorScheme.surfaceBright, seedScheme.surfaceBright);
       expect(
@@ -55,7 +64,6 @@ void main() {
         colorScheme.surfaceContainerHighest,
         seedScheme.surfaceContainerHighest,
       );
-      expect(colorScheme.surfaceTint, seedScheme.surfaceTint);
     });
   });
 }


### PR DESCRIPTION
## Description

Update `CorePalette.toColorScheme` to start from `ColorScheme.fromSeed` and then override with dynamic palette values, ensuring all newer surface-related roles are populated correctly (including `surfaceVariant` and `surfaceTint`). Add regression tests for light and dark schemes, adjust the example widget test to assert the seeded primary color, and document the fix in the changelog with linked issues.

<img width="400"  alt="Screenshot_1785862167" src="https://github.com/user-attachments/assets/1887d683-015b-426c-8130-8bd6ad466c79" />

<img width="400"  alt="Screenshot_1785862310" src="https://github.com/user-attachments/assets/05a68c7b-cae7-4895-b4af-d66ff228b963" />


## Tests

A regression test

## Issues
Fixes #574
Fixes #649
Fixes #582

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
