### PR TITLE
Fix Linux GNOME accent color detection

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,12 +15,13 @@ permissions:
 jobs:
   check_package:
     name: ${{ matrix.package }} using Flutter ${{ matrix.flutter-channel }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         package: [dynamic_color]
         flutter-channel: [stable, beta]
+        os: [macos-latest, ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,4 +47,20 @@ jobs:
 
       - name: Ensure Dart code is formatted correctly
         run: dart format --set-exit-if-changed .
+        working-directory: packages/${{ matrix.package }}
+
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libgtk-3-dev xvfb
+
+      - name: Run native Linux tests
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd example
+          flutter build linux --debug
+          cd linux
+          cmake -B build_test -S . -DBUILD_TESTING=ON
+          cmake --build build_test
+          cd build_test/plugins/dynamic_color
+          xvfb-run ctest --output-on-failure
         working-directory: packages/${{ matrix.package }}

--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Read GNOME's Linux accent-color setting before falling back to the GTK theme
+  color ([#658](https://github.com/material-foundation/flutter-packages/issues/658))
+
 - Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649))
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/packages/dynamic_color/README.md
+++ b/packages/dynamic_color/README.md
@@ -6,7 +6,8 @@ A Flutter package to create Material color schemes based on a platform's impleme
 
 - Android S+: user [wallpaper color](https://m3.material.io/styles/color/dynamic-color/user-generated-color#35bc06c5-35d9-4559-9f5d-07ea734cbcb1)
     - For color schemes from [content color](https://m3.material.io/styles/color/dynamic-color/user-generated-color#8af550b9-a19e-4e9f-bb0a-7f611fed5d0f), use [`ColorScheme.fromImageProvider`](https://api.flutter.dev/flutter/material/ColorScheme/fromImageProvider.html)
-- Linux: GTK+ theme's `@theme_selected_bg_color`
+- Linux: GNOME's `org.gnome.desktop.interface` `accent-color`, falling back to
+  the GTK+ theme's `@theme_selected_bg_color`
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 - Windows: [accent color](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color) or [window/glass color](https://web.archive.org/web/20080812195923/http://www.microsoft.com/windows/windows-vista/features/aero.aspx?tabid=2&catid=4)
 

--- a/packages/dynamic_color/example/lib/core_palette_visualization.dart
+++ b/packages/dynamic_color/example/lib/core_palette_visualization.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:io';
 
 import 'package:dynamic_color/dynamic_color.dart';

--- a/packages/dynamic_color/example/lib/get_core_palette_example.dart
+++ b/packages/dynamic_color/example/lib/get_core_palette_example.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';

--- a/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
+++ b/packages/dynamic_color/lib/src/corepalette_to_colorscheme.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:flutter/material.dart';
 import 'package:material_color_utilities/material_color_utilities.dart';
 

--- a/packages/dynamic_color/lib/src/dynamic_color_builder.dart
+++ b/packages/dynamic_color/lib/src/dynamic_color_builder.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/dynamic_color/lib/src/dynamic_color_plugin.dart
+++ b/packages/dynamic_color/lib/src/dynamic_color_plugin.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 
 import 'package:flutter/services.dart';

--- a/packages/dynamic_color/linux/CMakeLists.txt
+++ b/packages/dynamic_color/linux/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PLUGIN_NAME "dynamic_color_plugin")
 # Any new source files that you add to the plugin should be added here.
 add_library(${PLUGIN_NAME} SHARED
   "dynamic_color_plugin.cc"
+  "dynamic_color_plugin_color.cc"
 )
 
 # Apply a standard set of build settings that are configured in the
@@ -45,3 +46,14 @@ set(dynamic_color_bundled_libraries
   ""
   PARENT_SCOPE
 )
+
+if(BUILD_TESTING)
+  enable_testing()
+  add_executable(dynamic_color_plugin_color_test
+    "dynamic_color_plugin_color_test.cc"
+    "dynamic_color_plugin_color.cc"
+  )
+  target_link_libraries(dynamic_color_plugin_color_test PRIVATE PkgConfig::GTK)
+  add_test(NAME dynamic_color_plugin_color_test
+           COMMAND dynamic_color_plugin_color_test)
+endif()

--- a/packages/dynamic_color/linux/dynamic_color_plugin.cc
+++ b/packages/dynamic_color/linux/dynamic_color_plugin.cc
@@ -1,6 +1,8 @@
 #include "include/dynamic_color/dynamic_color_plugin.h"
+#include "dynamic_color_plugin_color.h"
 
 #include <flutter_linux/flutter_linux.h>
+#include <gio/gio.h>
 #include <gtk/gtk.h>
 #include <math.h>
 
@@ -15,10 +17,38 @@ struct _DynamicColorPlugin {
 
 G_DEFINE_TYPE(DynamicColorPlugin, dynamic_color_plugin, g_object_get_type())
 
+static gboolean get_gnome_accent_color(GdkRGBA* color) {
+  GSettingsSchemaSource* source = g_settings_schema_source_get_default();
+  if (source == nullptr) {
+    return FALSE;
+  }
+
+  g_autoptr(GSettingsSchema) schema = g_settings_schema_source_lookup(
+      source, "org.gnome.desktop.interface", TRUE);
+  if (schema == nullptr ||
+      !g_settings_schema_has_key(schema, "accent-color")) {
+    return FALSE;
+  }
+
+  g_autoptr(GSettings) settings = g_settings_new_full(schema, nullptr, nullptr);
+  g_autofree gchar* accent = g_settings_get_string(settings, "accent-color");
+
+  return dynamic_color_plugin_get_gnome_accent_color(accent, color);
+}
+
 static int get_accent_color(GtkWidget* widget) {
   GdkRGBA color;
+  if (get_gnome_accent_color(&color)) {
+    return lround(color.alpha * 255) << 24 | lround(color.red * 255) << 16 |
+           lround(color.green * 255) << 8 | lround(color.blue * 255);
+  }
+
+  color = GdkRGBA{};
   GtkStyleContext* context = gtk_widget_get_style_context(widget);
-  gtk_style_context_lookup_color(context, "theme_selected_bg_color", &color);
+  if (!gtk_style_context_lookup_color(context, "theme_selected_bg_color",
+                                      &color)) {
+    return 0;
+  }
   return lround(color.alpha * 255) << 24 | lround(color.red * 255) << 16 |
          lround(color.green * 255) << 8 | lround(color.blue * 255);
 }

--- a/packages/dynamic_color/linux/dynamic_color_plugin_color.cc
+++ b/packages/dynamic_color/linux/dynamic_color_plugin_color.cc
@@ -1,0 +1,23 @@
+#include "dynamic_color_plugin_color.h"
+
+gboolean dynamic_color_plugin_get_gnome_accent_color(const gchar* accent,
+                                                     GdkRGBA* color) {
+  struct Accent {
+    const char* name;
+    const char* value;
+  };
+  static constexpr Accent accents[] = {
+      {"blue", "#3584e4"},   {"teal", "#2190a4"},
+      {"green", "#3a944a"},  {"yellow", "#c88800"},
+      {"orange", "#ed5b00"}, {"red", "#e62d42"},
+      {"pink", "#d56199"},   {"purple", "#9141ac"},
+      {"slate", "#6f8396"},
+  };
+
+  for (const Accent& option : accents) {
+    if (g_strcmp0(accent, option.name) == 0) {
+      return gdk_rgba_parse(color, option.value);
+    }
+  }
+  return FALSE;
+}

--- a/packages/dynamic_color/linux/dynamic_color_plugin_color.h
+++ b/packages/dynamic_color/linux/dynamic_color_plugin_color.h
@@ -1,0 +1,11 @@
+#ifndef DYNAMIC_COLOR_PLUGIN_COLOR_H_
+#define DYNAMIC_COLOR_PLUGIN_COLOR_H_
+
+#include <gtk/gtk.h>
+
+// Converts a GNOME accent-color enum to its corresponding default palette
+// color. Returns FALSE for values that are not part of that palette.
+gboolean dynamic_color_plugin_get_gnome_accent_color(const gchar* accent,
+                                                     GdkRGBA* color);
+
+#endif  // DYNAMIC_COLOR_PLUGIN_COLOR_H_

--- a/packages/dynamic_color/linux/dynamic_color_plugin_color_test.cc
+++ b/packages/dynamic_color/linux/dynamic_color_plugin_color_test.cc
@@ -1,0 +1,28 @@
+#include "dynamic_color_plugin_color.h"
+
+#include <glib.h>
+
+static void test_known_accent_color() {
+  GdkRGBA color;
+  g_assert_true(
+      dynamic_color_plugin_get_gnome_accent_color("orange", &color));
+  g_assert_cmpfloat(color.red, ==, 0xed / 255.0);
+  g_assert_cmpfloat(color.green, ==, 0x5b / 255.0);
+  g_assert_cmpfloat(color.blue, ==, 0x00 / 255.0);
+  g_assert_cmpfloat(color.alpha, ==, 1.0);
+}
+
+static void test_unknown_accent_color() {
+  GdkRGBA color;
+  g_assert_false(
+      dynamic_color_plugin_get_gnome_accent_color("not-a-color", &color));
+}
+
+int main(int argc, char** argv) {
+  g_test_init(&argc, &argv, nullptr);
+  g_test_add_func("/dynamic_color/known_accent_color",
+                  test_known_accent_color);
+  g_test_add_func("/dynamic_color/unknown_accent_color",
+                  test_unknown_accent_color);
+  return g_test_run();
+}

--- a/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
+++ b/packages/dynamic_color/test/corepalette_to_colorscheme_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dynamic_color/src/corepalette_to_colorscheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,10 +16,13 @@ void main() {
       final lightScheme = Scheme.lightFromCorePalette(corePalette);
       expect(lightColorScheme.primary, Color(lightScheme.primary));
       expect(lightColorScheme.onPrimary, Color(lightScheme.onPrimary));
-      expect(lightColorScheme.primaryContainer, Color(lightScheme.primaryContainer));
-      expect(lightColorScheme.onPrimaryContainer, Color(lightScheme.onPrimaryContainer));
+      expect(lightColorScheme.primaryContainer,
+          Color(lightScheme.primaryContainer));
+      expect(lightColorScheme.onPrimaryContainer,
+          Color(lightScheme.onPrimaryContainer));
       expect(lightColorScheme.surface, Color(lightScheme.surface));
-      expect(lightColorScheme.surfaceVariant, Color(lightScheme.surfaceVariant));
+      expect(
+          lightColorScheme.surfaceVariant, Color(lightScheme.surfaceVariant));
       expect(lightColorScheme.surfaceTint, Color(lightScheme.primary));
 
       final darkColorScheme = corePalette.toColorScheme(
@@ -26,8 +31,10 @@ void main() {
       final darkScheme = Scheme.darkFromCorePalette(corePalette);
       expect(darkColorScheme.primary, Color(darkScheme.primary));
       expect(darkColorScheme.onPrimary, Color(darkScheme.onPrimary));
-      expect(darkColorScheme.primaryContainer, Color(darkScheme.primaryContainer));
-      expect(darkColorScheme.onPrimaryContainer, Color(darkScheme.onPrimaryContainer));
+      expect(
+          darkColorScheme.primaryContainer, Color(darkScheme.primaryContainer));
+      expect(darkColorScheme.onPrimaryContainer,
+          Color(darkScheme.onPrimaryContainer));
       expect(darkColorScheme.surface, Color(darkScheme.surface));
       expect(darkColorScheme.surfaceVariant, Color(darkScheme.surfaceVariant));
       expect(darkColorScheme.surfaceTint, Color(darkScheme.primary));


### PR DESCRIPTION
## Summary

- Read GNOME's `org.gnome.desktop.interface` `accent-color` setting on Linux.
- Map supported GNOME accent names to their palette colors.
- Preserve GTK `@theme_selected_bg_color` as a fallback.
- Add focused native Linux regression tests and update documentation.

## Root cause

The Linux plugin only queried the GTK theme's `theme_selected_bg_color` and never read GNOME's accent-color setting.

## Testing

- `git diff --check` passed.
- Not run: `flutter test`, `flutter analyze`, and native Linux tests because the configured Flutter Docker runner was unavailable (Docker daemon unavailable at `/Users/ghag23/.colima/default/docker.sock`).

Runtime GNOME/GTK verification remains outstanding because no isolated Linux desktop session was available. Runtime color-change notifications and broader GTK theme discovery remain out of scope for this change.

Fixes #658.
