### PR TITLE
Implement XDG portal for accent colors (pull-only)

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -1,39 +1,34 @@
 # Changelog
-
-- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649))
+- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([\#574](https://github.com/material-foundation/flutter-packages/issues/574), [\#582](https://github.com/material-foundation/flutter-packages/issues/582), [\#649](https://github.com/material-foundation/flutter-packages/issues/649))
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.9.0 - 2025-08-07
-
-### Fixed
-
-- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([#574](https://github.com/material-foundation/flutter-packages/issues/574), [#582](https://github.com/material-foundation/flutter-packages/issues/582), [#649](https://github.com/material-foundation/flutter-packages/issues/649))
-
+## Unreleased
 ### Added
+- Add support for the XDG Desktop Portal Settings for accent-color on Linux
 
+## 1.9.0 - 2025-08-07
+### Added
 - Add support for AGP 9
 
 ### Changed
-
 - Migrate to Kotlin DSL in Android
 - Update `compileSdk` to `flutter.compileSdkVersion`
 - Update `minSdk` to `24`
 - Update `targetSdk` to `flutter.targetSdkVersion`
-- Break out test utils from dynamic_color package into a separate package, `dynamic_color_testing`
+- Break out test utils from dynamic\_color package into a separate package, `dynamic_color_testing`
 - Update testing docs and examples to use `package:dynamic_color_testing/dynamic_color_testing.dart`
 
-## 1.8.1 - 2025-08-01
-
 ### Fixed
+- Populate the missing `ColorScheme` surface roles so dynamic color schemes render correctly ([\#574](https://github.com/material-foundation/flutter-packages/issues/574), [\#582](https://github.com/material-foundation/flutter-packages/issues/582), [\#649](https://github.com/material-foundation/flutter-packages/issues/649))
 
-- Revert moving flutter_test to dev_dependencies
+## 1.8.1 - 2025-08-01
+### Fixed
+- Revert moving flutter\_test to dev\_dependencies
 
 ## 1.8.0 - 2025-08-01
-
 ### Changed
-
 - Update `material_color_utilities` upper constraint to `0.13.0`
 - Update other dependencies
 - Update `compileSdkVersion` to `34`
@@ -41,184 +36,129 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Swift Package Manager compatibility [\#633](https://github.com/material-foundation/flutter-packages/issues/633).
 
 ### Fixed
-
-- Move flutter_test to dev_dependencies
+- Move flutter\_test to dev\_dependencies
 
 ## 1.7.0 - 2024-03-01
-
 ### Changed
-
 - Update `material_color_utilities` to `0.8.0`
 
 ## 1.6.9 - 2023-12-16
-
 ### Changed
-
 - Use `DynamicColors.isDynamicColorAvailable` from `com.google.android.material:material` to verify if dynamic colors are available on Android
 
 ## 1.6.8 - 2023-10-17
-
 ### Changed
-
 - Broaden constraint for `material_color_utilities` to support it until its `1.0.0` release
 
 ## 1.6.7 - 2023-09-15
-
 ### Fixed
-
 - Upgraded dependencies
 
 ## 1.6.6 - 2023-07-04
-
 ### Changed
-
 - Improved documentation for content-based color schemes
 
 ## 1.6.5 - 2023-05-15
-
 ### Changed
-
 - Broaden constraint for `material_color_utilities` to support multiple Flutter SDK versions
 
 ## 1.6.4 - 2023-05-05
-
 ### Changed
-
 - Update constraint for `material_color_utilities` to `0.5.0`
 
 ## 1.6.3 - 2023-04-04
-
 ### Changed
-
 - Update constraint for `material_color_utilities` to `0.3.0`
 
 ## 1.6.2 - 2023-02-03
-
 ### Added
-
 - Added screenshots
 
 ## 1.6.1 - 2023-02-03
-
 ### Changed
-
 - Update pubspec `repository`
 
 ## 1.6.0 - 2023-01-31
-
 ### Added
-
 - Add support for `outlineVariant` and `scrim` colors
 
 ### Changed
-
 - Update constraint for `material_color_utilities` to `0.2.0`
 - Update Flutter constraint
 - Make return value of toColorScheme extension method non-nullable ([\#55](https://github.com/material-foundation/material-dynamic-color-flutter/pull/55))
 
 ## 1.5.4 - 2022-09-02
-
 ### Changed
-
 - Update constraint for Flutter SDK
 
 ## 1.5.3 - 2022-08-09
-
 ### Changed
-
 - Update constraint for `material_color_utilities`
 
 ## 1.5.2 - 2022-08-02
-
 ### Added
-
 - Add support for DWM/Windows Aero's color ([\#50](https://github.com/material-foundation/material-dynamic-color-flutter/pull/50))
 - Add support for GTK's accent color on Linux ([\#47](https://github.com/material-foundation/material-dynamic-color-flutter/pull/47))
 - Add example tests
 
 ### Changed
-
 - Expand and improve README
 - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `colorPalette` to `corePalette`
 - Improve `DynamicColorBuilder` short-circuiting logic if dynamic color is detected
 - Tweak debugging messages
 
 ## 1.4.0 - 2022-05-31
-
 ### Added
-
 - Add support for Windows' accent color ([\#43](https://github.com/material-foundation/material-dynamic-color-flutter/pull/43))
 
 ### Changed
-
 - Rename `DynamicColorPlugin.getControlAccentColor` to `DynamicColorPlugin.getAccentColor`
 - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `controlAccentColor` to `accentColor`
 
 ## 1.3.0 - 2022-05-25
-
 ### Added
-
 - Add support for macOS' control accent color ([\#42](https://github.com/material-foundation/material-dynamic-color-flutter/pull/42))
   - Rename `DynamicColorTestingUtils.setMockDynamicColors`'s argument `colors` to `colorPalette`
 
 ## 1.2.3 - 2022-05-23
-
 ### Changed
-
 - Tweak pubspec description
 
 ## 1.2.2 - 2022-04-25
-
 ### Changed
-
 - Update lower Flutter SDK bound
 
 ## 1.2.0 - 2022-03-24
-
 ### Changed
-
 - Improve examples: show how to create dynamic and fallback color schemes, and use harmonization for color schemes and custom colors
 
 ## 1.1.2 - 2022-02-15
-
 ### Changed
-
 - Move samples to their own library
 
 ## 1.1.1 - 2022-02-14
-
 ### Changed
-
 - Provide sample `CorePalette`s and corresponding `ColorScheme`s to test utils
 - Make the extension method which converts a `CorePalette` to a `ColorScheme` public
 
 ## 1.1.0 - 2022-02-08
-
 ### Changed
-
 - Qualify builder parameters (`light` => `lightDynamic`, `dark` => `darkDynamic`) for clarity
 
 ## 1.0.1 - 2022-02-02
-
 ### Changed
-
 - Polish README and examples
 
 ## 1.0.0 - 2022-02-02
-
 ### Added
-
 - Add missing semantic colors to harmonization from updated m3 color scheme
 
 ### Changed
-
 - `DynamicColorBuilder`'s `builder` now provides a light and dark `ColorScheme` rather than a `CorePalette`
   - Advanced users can still obtain the palette with `DynamicColorPlugin.getCorePalette()`
 
 ## 0.1.0 - 2021-10-29
-
 ### Added
-
 - Create `CorePalette` and `TonalPalette` classes
 - Create `DynamicColorPlugin` plugin
 - Create convenience `DynamicColorBuilder` widget

--- a/packages/dynamic_color/README.md
+++ b/packages/dynamic_color/README.md
@@ -6,7 +6,7 @@ A Flutter package to create Material color schemes based on a platform's impleme
 
 - Android S+: user [wallpaper color](https://m3.material.io/styles/color/dynamic-color/user-generated-color#35bc06c5-35d9-4559-9f5d-07ea734cbcb1)
     - For color schemes from [content color](https://m3.material.io/styles/color/dynamic-color/user-generated-color#8af550b9-a19e-4e9f-bb0a-7f611fed5d0f), use [`ColorScheme.fromImageProvider`](https://api.flutter.dev/flutter/material/ColorScheme/fromImageProvider.html)
-- Linux: GTK+ theme's `@theme_selected_bg_color`
+- Linux: [XDG Desktop Portal Settings] or GTK+ theme's `@theme_selected_bg_color`
 - macOS: [app accent color](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#app-accent-colors)
 - Windows: [accent color](https://docs.microsoft.com/en-us/windows/apps/design/style/color#accent-color) or [window/glass color](https://web.archive.org/web/20080812195923/http://www.microsoft.com/windows/windows-vista/features/aero.aspx?tabid=2&catid=4)
 
@@ -119,3 +119,4 @@ flutter build web
 [harmonization.dart]: https://github.com/material-foundation/flutter-packages/blob/main/packages/dynamic_color/lib/src/harmonization.dart
 [example app]: https://material-foundation.github.io/flutter-packages/dynamic_color
 [accent color example]: https://github.com/material-foundation/flutter-packages/blob/main/packages/dynamic_color/example/lib/accent_color.dart
+[XDG Desktop Portal Settings]: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html

--- a/packages/dynamic_color/linux/dynamic_color_plugin.cc
+++ b/packages/dynamic_color/linux/dynamic_color_plugin.cc
@@ -23,14 +23,54 @@ static int get_accent_color(GtkWidget* widget) {
          lround(color.green * 255) << 8 | lround(color.blue * 255);
 }
 
+static gboolean get_xdg_portal_accent_color(int* out_argb) {
+  g_autoptr(GDBusConnection) connection =
+      g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, nullptr);
+  if (!connection) {
+    return FALSE;
+  }
+
+  g_autoptr(GVariant) result = g_dbus_connection_call_sync(
+      connection, "org.freedesktop.portal.Desktop",
+      "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings",
+      "Read",
+      g_variant_new("(ss)", "org.freedesktop.appearance", "accent-color"),
+      G_VARIANT_TYPE("(v)"), G_DBUS_CALL_FLAGS_NONE, -1, nullptr, nullptr);
+
+  if (!result) {
+    return FALSE;
+  }
+
+  g_autoptr(GVariant) inner = nullptr;
+  g_variant_get(result, "(v)", &inner);
+  if (!inner) {
+    return FALSE;
+  }
+
+  g_autoptr(GVariant) actual_value = g_variant_get_variant(inner);
+  if (actual_value &&
+      g_variant_is_of_type(actual_value, G_VARIANT_TYPE("(ddd)"))) {
+    double r, g, b;
+    g_variant_get(actual_value, "(ddd)", &r, &g, &b);
+    *out_argb = (255 << 24) | (lround(r * 255) << 16) | (lround(g * 255) << 8) |
+                lround(b * 255);
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
 static void dynamic_color_plugin_handle_method_call(DynamicColorPlugin* self,
                                                     FlMethodCall* method_call) {
   g_autoptr(FlMethodResponse) response = nullptr;
 
   const gchar* method = fl_method_call_get_name(method_call);
   if (strcmp(method, "getAccentColor") == 0) {
-    FlView* view = fl_plugin_registrar_get_view(self->registrar);
-    int argb = get_accent_color(GTK_WIDGET(view));
+    int argb;
+    if (!get_xdg_portal_accent_color(&argb)) {
+      FlView* view = fl_plugin_registrar_get_view(self->registrar);
+      argb = get_accent_color(GTK_WIDGET(view));
+    }
     g_autoptr(FlValue) result = fl_value_new_int(argb);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(result));
   } else {


### PR DESCRIPTION
## Description

This pull request implements support for the `org.freedesktop.appearance` `accent-color` key from the XDG desktop settings portal. Tested under my own system this allows for better accent color support under GNOME (and likely other desktops like KDE).

<img width="1920" height="1200" alt="Screenshot" src="https://github.com/user-attachments/assets/4e9a55da-3f31-48d9-9c2a-547e539a635c" />

The work is half-way done, this PR does not add support for the [`SettingChanged`](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html#org-freedesktop-portal-settings-settingchanged) signal, which would allow changing colors at runtime.

I would potentially work on implementing this too. It seems like as of now, there is no interop code for plugin-side notifications about the accent color changing (see #300), requiring more base work before the signal can be implemented.

The reformatting of the CHANGELOG.md seems to be a result of either my IDE or the cider package, if desired I can remove the reformat :)

## Tests

As this doesn't touch Dart code and only implements native code, there are no corresponding tests.

## Issues
Fixes #624

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
