### PR TITLE
Fix(dynamic_color): apply Kotlin plugin conditionally for AGP 8.x compatibility

### DIFF
--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -5,7 +5,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.9.1 - 2026-08-13
 
 ### Fixed
 

--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Apply Kotlin Android plugin conditionally for AGP 8.x compatibility ([\#695](https://github.com/material-foundation/flutter-packages/issues/695))
+- Apply Kotlin Android plugin conditionally for AGP version before 9 compatibility ([\#695](https://github.com/material-foundation/flutter-packages/issues/695))
 
 ## 1.9.0 - 2025-08-07
 

--- a/packages/dynamic_color/CHANGELOG.md
+++ b/packages/dynamic_color/CHANGELOG.md
@@ -5,6 +5,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Apply Kotlin Android plugin conditionally for AGP 8.x compatibility ([\#695](https://github.com/material-foundation/flutter-packages/issues/695))
+
 ## 1.9.0 - 2025-08-07
 
 ### Fixed

--- a/packages/dynamic_color/android/build.gradle.kts
+++ b/packages/dynamic_color/android/build.gradle.kts
@@ -25,7 +25,13 @@ plugins {
     id("com.android.library")
 }
 
-kotlin {
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }

--- a/packages/dynamic_color/example/pubspec.lock
+++ b/packages/dynamic_color/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.0"
+    version: "1.9.1"
   dynamic_color_testing:
     dependency: "direct dev"
     description:

--- a/packages/dynamic_color/pubspec.yaml
+++ b/packages/dynamic_color/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dynamic_color
 description: A Flutter package to create Material color schemes based on a platform's implementation of dynamic color.
-version: 1.9.0
+version: 1.9.1
 repository: https://github.com/material-foundation/flutter-packages/tree/main/packages/dynamic_color
 issue_tracker: https://github.com/material-foundation/flutter-packages/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+dynamic_color%22
 screenshots:


### PR DESCRIPTION
## Description

This change adds an AGP version check so that `apply(plugin = "org.jetbrains.kotlin.android")` is only executed on AGP 8.x and below, where it is required. AGP 9.x and above handle Kotlin plugin application automatically and no longer need this explicit apply.

## Tests

No Dart code was modified. Build compatibility has been verified against both AGP 8.x and 9.x.

## Issues
Fixes #695 

## Checklist

- [x] I've reviewed the [contribution guide](https://github.com/material-foundation/flutter-packages/blob/main/CONTRIBUTING.md).
- [x] I've updated the package `CHANGELOG.md`
